### PR TITLE
Fixed error 'The limit parameter has to be between 0 and 400'

### DIFF
--- a/get_migros_ids.sh
+++ b/get_migros_ids.sh
@@ -2,7 +2,7 @@
 # Get and print the IDs of every Migros food products
 # Requires curl, jq>=1.5
 
-NB_RESULTS=1000
+NB_RESULTS=400
 
 # get_ids <offset>
 get_ids() {


### PR DESCRIPTION
Tried to run the first script and it failed. The problem was that Migros now only allows 400 products at a time:

`The limit parameter has to be between 0 and 400`

This PR fixes that issue